### PR TITLE
Switch form bug

### DIFF
--- a/src/js/controllers/walletHome.js
+++ b/src/js/controllers/walletHome.js
@@ -1566,10 +1566,12 @@ angular.module('copayApp.controllers')
 						return self.resetForm();
 					}
 					$scope.index.assetIndex = assetIndex;
+				$scope.assetIndexSelectorValue = assetIndex;
 					this.lockAsset = true;
 				}
 				else
 					this.lockAsset = false;
+				this.switchForms();
 			}).bind(this), 1);
 		};
 
@@ -1598,6 +1600,9 @@ angular.module('copayApp.controllers')
 						$scope.home.poll_question = dataPrompt.question;
 						delete dataPrompt.question;
 						break;
+					case 'vote':
+						notification.error('voting not yet supported via uri');
+						return self.resetForm();
 				}
 				$scope.home.feedvaluespairs = [];
 				for (var key in dataPrompt) {

--- a/src/js/controllers/walletHome.js
+++ b/src/js/controllers/walletHome.js
@@ -1566,7 +1566,7 @@ angular.module('copayApp.controllers')
 						return self.resetForm();
 					}
 					$scope.index.assetIndex = assetIndex;
-				$scope.assetIndexSelectorValue = assetIndex;
+					$scope.assetIndexSelectorValue = assetIndex;
 					this.lockAsset = true;
 				}
 				else


### PR DESCRIPTION
Fixed bugs:
* when data form is selected in wallet and then user clicks on `byteball:` payment uri, form didn't switch to payment and stayed on previously selected data form.
* voting is not yet supported via `byteball:` uri, so if error notification is not shown then it was showing previously selected data form.

Couldn't find a fix:
* if blackbytes or custom asset form is selected and then user clicks on `byteball:` payment uri for bytes, form validation will be false and there is "Not valid" text on amount field.