### PR TITLE
Buffer DeprecationWarning

### DIFF
--- a/angular-bitcore-wallet-client/bitcore-wallet-client/lib/api.js
+++ b/angular-bitcore-wallet-client/bitcore-wallet-client/lib/api.js
@@ -286,7 +286,7 @@ API.prototype.decryptBIP38PrivateKey = function(encryptedPrivateKeyBase58, passp
 
   var privateKey = new Bitcore.PrivateKey(privateKeyWif);
   var address = privateKey.publicKey.toAddress().toString();
-  var addrBuff = new Buffer(address, 'ascii');
+  var addrBuff = new Buffer.from(address, 'ascii');
   var actualChecksum = Bitcore.crypto.Hash.sha256sha256(addrBuff).toString('hex').substring(0, 8);
   var expectedChecksum = Bitcore.encoding.Base58Check.decode(encryptedPrivateKeyBase58).toString('hex').substring(6, 14);
 

--- a/angular-bitcore-wallet-client/bitcore-wallet-client/lib/credentials.js
+++ b/angular-bitcore-wallet-client/bitcore-wallet-client/lib/credentials.js
@@ -126,7 +126,7 @@ Credentials.fromExtendedPublicKey = function(xPubKey, source, entropySourceHex, 
   $.shouldBeNumber(account);
   $.checkArgument(_.includes(_.values(Constants.DERIVATION_STRATEGIES), derivationStrategy));
 
-  var entropyBuffer = new Buffer(entropySourceHex, 'hex');
+  var entropyBuffer = new Buffer.from(entropySourceHex, 'hex');
   //require at least 112 bits of entropy
   $.checkArgument(entropyBuffer.length >= 14, 'At least 112 bits of entropy are needed')
 
@@ -149,8 +149,8 @@ Credentials._getNetworkFromExtendedKey = function(xKey) {
 
 Credentials.prototype._hashFromEntropy = function(prefix, length) {
   $.checkState(prefix);
-  var b = new Buffer(this.entropySource, 'hex');
-  var b2 = Bitcore.crypto.Hash.sha256hmac(b, new Buffer(prefix));
+  var b = new Buffer.from(this.entropySource, 'hex');
+  var b2 = Bitcore.crypto.Hash.sha256hmac(b, new Buffer.from(prefix));
   return b2.slice(0, length);
 };
 

--- a/i18n/crowdin_download.js
+++ b/i18n/crowdin_download.js
@@ -73,7 +73,7 @@ if (no_key == false) { // Reminder: Any changes to the script below must also be
             data.push(chunk);
             dataLen += chunk.length;
           }).on('end', function() {
-            var buf = new Buffer(dataLen);
+            var buf = new Buffer.assoc(dataLen);
             for (var i=0, len = data.length, pos = 0; i < len; i++) {
               data[i].copy(buf, pos);
               pos += data[i].length;
@@ -167,7 +167,7 @@ if (no_key == false) { // Reminder: Any changes to the script below must also be
         data.push(chunk);
         dataLen += chunk.length;
       }).on('end', function() {
-        var buf = new Buffer(dataLen);
+        var buf = new Buffer.assoc(dataLen);
         for (var i=0, len = data.length, pos = 0; i < len; i++) {
           data[i].copy(buf, pos);
           pos += data[i].length;

--- a/src/js/services/correspondentListService.js
+++ b/src/js/services/correspondentListService.js
@@ -104,10 +104,10 @@ angular.module('copayApp.services').factory('correspondentListService', function
 	
 	
 	// payment description within [] is ignored and whole URI is capturing group
-	var payment_request_regexp = /\[.*?\]\(((?:byteball|obyte):([0-9A-Z]{32})(?:\?([\w=&;+%]+))?)\)/g;
-	var pairing_regexp = /\[.*?\]\(((?:byteball|obyte):([\w\/+]{44})@([\w.:\/-]+)#(.+))\)/g;
-	var textcoin_regexp = /\[.*?\]\(((?:byteball|obyte):textcoin\?(.+))\)/g;
-	var data_regexp = /\[.*?\]\(((?:byteball|obyte):data\?(.+))\)/g;
+	var payment_request_regexp = /\[.*?\]\(((?:byteball-tn|byteball|obyte-tn|obyte):([0-9A-Z]{32})(?:\?([\w=&;+%]+))?)\)/g;
+	var pairing_regexp = /\[.*?\]\(((?:byteball-tn|byteball|obyte-tn|obyte):([\w\/+]{44})@([\w.:\/-]+)#(.+))\)/g;
+	var textcoin_regexp = /\[.*?\]\(((?:byteball-tn|byteball|obyte-tn|obyte):textcoin\?(.+))\)/g;
+	var data_regexp = /\[.*?\]\(((?:byteball-tn|byteball|obyte-tn|obyte):data\?(.+))\)/g;
 
 	function paymentDropdown(address) {
 		return '<a dropdown-toggle="#pop'+address+'">'+address+'</a><ul id="pop'+address+'" class="f-dropdown" style="left:0px" data-dropdown-content><li><a ng-click="sendPayment(\''+address+'\')">'+gettext('Pay to this address')+'</a></li><li><a ng-click="offerContract(\''+address+'\')">'+gettext('Offer a contract')+'</a></li><li><a ng-click="offerProsaicContract(\''+address+'\')">'+gettext('Offer prosaic contract')+'</a></li></ul>';


### PR DESCRIPTION
This warning appears on Node v10 and above: `(node:1) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.`

Buffer.alloc() and Buffer.from() has been since Node v4.