### PR TITLE
fix lengths

### DIFF
--- a/public/views/walletHome.html
+++ b/public/views/walletHome.html
@@ -484,7 +484,7 @@ input.datafeed_input {
 	                </label>
 	                <div class="input">
 	                  <textarea id="comment" ng-disabled="home.blockUx" name="comment"
-	                    ng-maxlength="500" ng-model="_comment" ng-focus="home.formFocus('msg')"
+	                    ng-maxlength="500" maxlength="500" ng-model="_comment" ng-focus="home.formFocus('msg')"
 	                    ng-blur="home.formFocus(false)"></textarea>
 	                </div>
 	              </div>
@@ -657,7 +657,7 @@ input.datafeed_input {
 					<label style="float: left;">
 						<span translate>Question to be voted on</span>
 					</label>
-					<input type="text" name="poll_question" ng-model="home.poll_question" placeholder="Poll question" ng-required="true">
+					<input type="text" name="poll_question" ng-model="home.poll_question" placeholder="Poll question" ng-required="true" ng-maxlength="256" maxlength="256">
 				</div>
 				<div class="row m20t" ng-if="assetIndexSelectorValue == -6">
 					<label style="float: left;">
@@ -671,7 +671,7 @@ input.datafeed_input {
           <label style="float: left;">
             <span translate>Text to be forever saved on the DAG:</span>
           </label>
-          <textarea name="content" ng-model="home.content" placeholder="Text" required rows="4" ng-change="home.validateTextLength()" style="margin-bottom: 0px;/*font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;*/" ng-trim="false"></textarea>
+          <textarea name="content" ng-model="home.content" placeholder="Text" required rows="10" ng-change="home.validateTextLength()" style="margin-bottom: 0px;/*font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;*/" ng-trim="false"></textarea>
           <div ng-if="sendDataForm.content.$invalid && home.content" class="text-warning size-12" translate>Too long text</div>
           <div ng-if="sendDataForm.content.$valid || !home.content" class="size-12">{{home.content.length || 0}} <span translate>character(s)</span></div>
         </div>
@@ -680,8 +680,8 @@ input.datafeed_input {
 						<span>{{(assetIndexSelectorValue == -5 ? 'Options for answering' : 'Values')|translate}}</span>
 					</label>
 					<span ng-repeat="pair in home.feedvaluespairs">
-						<input type="text" ng-model="pair.name" ng-readonly="pair.readonly" placeholder="{{([-2, -3].includes(assetIndexSelectorValue) ? 'Profile field' : ([-4, -5].includes(assetIndexSelectorValue) ? (assetIndexSelectorValue == -4 ? 'Field' : 'Answer') : 'Datafeed name'))|translate}}" class="datafeed_input" ng-required="true" ng-maxlength="64" maxlength="64" ng-style="(assetIndexSelectorValue == -5 ? {'width':'90%'} : {})">
-						<input ng-if="assetIndexSelectorValue != -5" type="text" ng-model="pair.value" ng-readonly="pair.readonly" placeholder="{{([-2, -3].includes(assetIndexSelectorValue) ? 'Profile field value' : (assetIndexSelectorValue == -4 ? 'Value' : 'Datafeed value'))|translate}}" class="datafeed_input" ng-required="true" maxlength="256">
+						<input type="text" ng-model="pair.name" ng-readonly="pair.readonly" placeholder="{{([-2, -3].includes(assetIndexSelectorValue) ? 'Profile field' : ([-4, -5].includes(assetIndexSelectorValue) ? (assetIndexSelectorValue == -4 ? 'Field' : 'Answer') : 'Datafeed name'))|translate}}" class="datafeed_input" ng-required="true" ng-maxlength="{{(assetIndexSelectorValue == -3 ? '50' : '64')}}" maxlength="{{(assetIndexSelectorValue == -3 ? '50' : '64')}}" ng-style="(assetIndexSelectorValue == -5 ? {'width':'90%'} : {})">
+						<input ng-if="assetIndexSelectorValue != -5" type="text" ng-model="pair.value" ng-readonly="pair.readonly" placeholder="{{([-2, -3].includes(assetIndexSelectorValue) ? 'Profile field value' : (assetIndexSelectorValue == -4 ? 'Value' : 'Datafeed value'))|translate}}" class="datafeed_input" ng-required="true" ng-maxlength="{{(assetIndexSelectorValue == -1 ? '64' : (assetIndexSelectorValue == -3 ? '100' : '256'))}}" maxlength="{{(assetIndexSelectorValue == -1 ? '64' : (assetIndexSelectorValue == -3 ? '100' : '256'))}}">
 						<a ng-if="!pair.readonly" ng-show="$last && !$first" ng-click="home.feedvaluespairs.splice(home.feedvaluespairs.length-1)"><i class="fi-minus size-18 m10r" style="vertical-align: middle;"></i></a>
 					</span>
 					<i data-trans="{{'Add answer' | translate}}" data-trans="{{'Add fields' | translate}}" data-trans="{{'Options for answering' | translate}}" data-trans="{{'Values' | translate}}" data-trans="{{'Answer' | translate}}" data-trans="{{'Field' | translate}}" data-trans="{{'Profile field' | translate}}" data-trans="{{'Datafeed name' | translate}}" data-trans="{{'Profile field value' | translate}}" data-trans="{{'Value' | translate}}" data-trans="{{'Datafeed value' | translate}}" data-trans="{{'confirmed' | translate}}" data-trans="{{'available' | translate}}" ></i>

--- a/src/js/controllers/walletHome.js
+++ b/src/js/controllers/walletHome.js
@@ -869,7 +869,7 @@ angular.module('copayApp.controllers')
 
 		this.validateTextLength = function () {
 			var form = $scope.sendDataForm;
-			form.content.$setValidity('validLength', !(self.content && self.content.length > 140));
+			form.content.$setValidity('validLength', !(self.content && self.content.length > 280));
 		}
 
 		this.onAddressChanged = function () {


### PR DESCRIPTION
Text should be as long as modern tweets (280 chars) and longer than any data (profile, poll, attestation) limits, otherwise someone wanting to timestamp some text would post it as something else, which has higher limit.

* change text from 140 to 280 and made textarea as high as the definition text area.
* added character limit to poll question, previously only poll options were limited.
* fixed profile key and value lengths to match lengths in constants.js
* fixed datafeed value length to be limited to 64 while keeping the raw data value to 256.
* some inputs had `ng-maxlength` and `maxlength`, some only ng-maxlength. made all have both.