### PR TITLE
User friendly signed messages

### DIFF
--- a/public/views/correspondentDevice.html
+++ b/public/views/correspondentDevice.html
@@ -410,6 +410,11 @@ Chat bubble CSS credits http://codepen.io/samuelkraft/pen/Farhl
 			  	</a>
 			  	<span class="ellipsis-end">)</span>
 			  </li>
+			  <li class="dropup-item">
+			  	<a ng-click="requestToSignMessage(chatForm.message.$modelValue)" class="ellipsis dropup-item-link">
+			  		<span translate>Request to sign message</span>
+			  	</a>
+			  </li>
 			  <div class="clear"></div>
 			  <li class="dropup-item">
 			  	<a ng-click="choosePrivateProfile()" class="ellipsis dropup-item-link">

--- a/public/views/correspondentDevice.html
+++ b/public/views/correspondentDevice.html
@@ -410,6 +410,7 @@ Chat bubble CSS credits http://codepen.io/samuelkraft/pen/Farhl
 			  	</a>
 			  	<span class="ellipsis-end">)</span>
 			  </li>
+			  <div class="clear"></div>
 			  <li class="dropup-item">
 			  	<a ng-click="requestToSignMessage(chatForm.message.$modelValue)" class="ellipsis dropup-item-link">
 			  		<span translate>Request to sign message</span>

--- a/public/views/correspondentDevice.html
+++ b/public/views/correspondentDevice.html
@@ -426,12 +426,6 @@ Chat bubble CSS credits http://codepen.io/samuelkraft/pen/Farhl
 			  </li>
 			  <div class="clear"></div>
 			  <li class="dropup-item">
-			  	<a ng-click="requestToSignMessage(chatForm.message.$modelValue)" class="ellipsis dropup-item-link">
-			  		<span translate>Request to sign message</span>
-			  	</a>
-			  </li>
-			  <div class="clear"></div>
-			  <li class="dropup-item">
 			  	<a ng-click="choosePrivateProfile()" class="ellipsis dropup-item-link">
 			  		<span translate>Insert private profile</span>
 			  	</a>

--- a/public/views/modals/sign-message.html
+++ b/public/views/modals/sign-message.html
@@ -16,10 +16,10 @@
 	
 	<h4 class="title m0 row columns" translate>Message:</h4>
   <div class="m10b m10t row columns size-14 enable_text_select" style="overflow-wrap: break-word;">
-    <span ng-if="isString(message_to_sign)" dynamic="escapeHtmlAndInsertBr(message_to_sign)"></span>
+    <span ng-if="isString(message_to_sign)" dynamic="escapeJSONAndInsertBr(message_to_sign)"></span>
     <ul ng-if="!isString(message_to_sign)">
       <li ng-repeat="(key, value) in message_to_sign">
-        <b>{{key}}:</b> <i dynamic="escapeHtmlAndInsertBr(value)"></i><br>
+        <b>{{key}}:</b> <i dynamic="escapeJSONAndInsertBr(value)"></i><br>
       </li>
     </ul>
 	</div>

--- a/public/views/modals/sign-message.html
+++ b/public/views/modals/sign-message.html
@@ -16,7 +16,7 @@
 	
 	<h4 class="title m0 row columns" translate>Message:</h4>
   <div class="m10b m10t row columns size-14 enable_text_select" style="overflow-wrap: break-word;">
-    <span ng-if="isString(message_to_sign)" style="white-space: pre-wrap;">{{message_to_sign}}</span>
+    <span ng-if="isString(message_to_sign)">{{message_to_sign}}</span>
     <ul ng-if="!isString(message_to_sign)">
       <li ng-repeat="(key, value) in message_to_sign">
         <b>{{key}}:</b> <i style="white-space: pre-wrap;">{{prettyPrint(value)}}</i><br>

--- a/public/views/modals/sign-message.html
+++ b/public/views/modals/sign-message.html
@@ -16,7 +16,7 @@
 	
 	<h4 class="title m0 row columns" translate>Message:</h4>
   <div class="m10b m10t row columns size-14 enable_text_select" style="overflow-wrap: break-word;">
-    <span ng-if="isString(message_to_sign)" style="white-space: pre-wrap;">{{prettyPrint(message_to_sign)}}</span>
+    <span ng-if="isString(message_to_sign)" style="white-space: pre-wrap;">{{message_to_sign}}</span>
     <ul ng-if="!isString(message_to_sign)">
       <li ng-repeat="(key, value) in message_to_sign">
         <b>{{key}}:</b> <i style="white-space: pre-wrap;">{{prettyPrint(value)}}</i><br>

--- a/public/views/modals/sign-message.html
+++ b/public/views/modals/sign-message.html
@@ -16,10 +16,10 @@
 	
 	<h4 class="title m0 row columns" translate>Message:</h4>
   <div class="m10b m10t row columns size-14 enable_text_select" style="overflow-wrap: break-word;">
-    <span ng-if="isString(message_to_sign)" dynamic="escapeJSONAndInsertBr(message_to_sign)"></span>
+    <span ng-if="isString(message_to_sign)" style="white-space: pre-wrap;">{{prettyPrint(message_to_sign)}}</span>
     <ul ng-if="!isString(message_to_sign)">
       <li ng-repeat="(key, value) in message_to_sign">
-        <b>{{key}}:</b> <i dynamic="escapeJSONAndInsertBr(value)"></i><br>
+        <b>{{key}}:</b> <i style="white-space: pre-wrap;">{{prettyPrint(value)}}</i><br>
       </li>
     </ul>
 	</div>

--- a/public/views/modals/sign-message.html
+++ b/public/views/modals/sign-message.html
@@ -15,11 +15,17 @@
 <div class="modal-content fix-modals-touch">
 	
 	<h4 class="title m0 row columns" translate>Message:</h4>
-	<div class="m10b m10t row columns size-14" style="overflow-wrap: break-word;" dynamic="message_to_sign">
+  <div class="m10b m10t row columns size-14 enable_text_select" style="overflow-wrap: break-word;">
+    <span ng-if="isString(message_to_sign)" dynamic="escapeHtmlAndInsertBr(message_to_sign)"></span>
+    <ul ng-if="!isString(message_to_sign)">
+      <li ng-repeat="(key, value) in message_to_sign">
+        <b>{{key}}:</b> <i dynamic="escapeHtmlAndInsertBr(value)"></i><br>
+      </li>
+    </ul>
 	</div>
 	
 	<h4 class="title m0 row columns" translate>Signing address:</h4>
-	<div class="m10b m10t row columns size-14" >
+	<div class="m10b m10t row columns size-14 enable_text_select" >
 		{{address}}
 	</div>
 	

--- a/public/views/modals/sign-message.html
+++ b/public/views/modals/sign-message.html
@@ -16,7 +16,7 @@
 	
 	<h4 class="title m0 row columns" translate>Message:</h4>
   <div class="m10b m10t row columns size-14 enable_text_select" style="overflow-wrap: break-word;">
-    <span ng-if="isString(message_to_sign)">{{message_to_sign}}</span>
+    <span ng-if="isString(message_to_sign)" style="white-space: pre-wrap;">{{message_to_sign}}</span>
     <ul ng-if="!isString(message_to_sign)">
       <li ng-repeat="(key, value) in message_to_sign">
         <b>{{key}}:</b> <i style="white-space: pre-wrap;">{{prettyPrint(value)}}</i><br>

--- a/public/views/modals/signed-message.html
+++ b/public/views/modals/signed-message.html
@@ -16,10 +16,10 @@
 	
 	<h4 class="title m0 row columns" translate>Message:</h4>
   <div class="m10b m10t row columns size-14 enable_text_select" style="overflow-wrap: break-word;">
-    <span ng-if="isString(signed_message)" dynamic="escapeHtmlAndInsertBr(signed_message)"></span>
+    <span ng-if="isString(signed_message)" dynamic="escapeJSONAndInsertBr(signed_message)"></span>
     <ul ng-if="!isString(signed_message)">
       <li ng-repeat="(key, value) in signed_message">
-        <b>{{key}}:</b> <i dynamic="escapeHtmlAndInsertBr(value)"></i><br>
+        <b>{{key}}:</b> <i dynamic="escapeJSONAndInsertBr(value)"></i><br>
       </li>
     </ul>
 	</div>

--- a/public/views/modals/signed-message.html
+++ b/public/views/modals/signed-message.html
@@ -15,7 +15,13 @@
 <div class="modal-content fix-modals-touch">
 	
 	<h4 class="title m0 row columns" translate>Message:</h4>
-	<div class="m10b m10t row columns size-14 enable_text_select" style="overflow-wrap: break-word;" dynamic="signed_message">
+  <div class="m10b m10t row columns size-14 enable_text_select" style="overflow-wrap: break-word;">
+    <span ng-if="isString(signed_message)" dynamic="escapeHtmlAndInsertBr(signed_message)"></span>
+    <ul ng-if="!isString(signed_message)">
+      <li ng-repeat="(key, value) in signed_message">
+        <b>{{key}}:</b> <i dynamic="escapeHtmlAndInsertBr(value)"></i><br>
+      </li>
+    </ul>
 	</div>
 	
 	<h4 class="title m0 row columns" translate>Signing address:</h4>

--- a/public/views/modals/signed-message.html
+++ b/public/views/modals/signed-message.html
@@ -16,10 +16,10 @@
 	
 	<h4 class="title m0 row columns" translate>Message:</h4>
   <div class="m10b m10t row columns size-14 enable_text_select" style="overflow-wrap: break-word;">
-    <span ng-if="isString(signed_message)" dynamic="escapeJSONAndInsertBr(signed_message)"></span>
+    <span ng-if="isString(signed_message)" style="white-space: pre-wrap;">{{prettyPrint(signed_message)}}</span>
     <ul ng-if="!isString(signed_message)">
       <li ng-repeat="(key, value) in signed_message">
-        <b>{{key}}:</b> <i dynamic="escapeJSONAndInsertBr(value)"></i><br>
+        <b>{{key}}:</b> <i style="white-space: pre-wrap;">{{prettyPrint(value)}}</i><br>
       </li>
     </ul>
 	</div>

--- a/public/views/modals/signed-message.html
+++ b/public/views/modals/signed-message.html
@@ -16,7 +16,7 @@
 	
 	<h4 class="title m0 row columns" translate>Message:</h4>
   <div class="m10b m10t row columns size-14 enable_text_select" style="overflow-wrap: break-word;">
-    <span ng-if="isString(signed_message)" style="white-space: pre-wrap;">{{signed_message}}</span>
+    <span ng-if="isString(signed_message)">{{signed_message}}</span>
     <ul ng-if="!isString(signed_message)">
       <li ng-repeat="(key, value) in signed_message">
         <b>{{key}}:</b> <i style="white-space: pre-wrap;">{{prettyPrint(value)}}</i><br>

--- a/public/views/modals/signed-message.html
+++ b/public/views/modals/signed-message.html
@@ -16,7 +16,7 @@
 	
 	<h4 class="title m0 row columns" translate>Message:</h4>
   <div class="m10b m10t row columns size-14 enable_text_select" style="overflow-wrap: break-word;">
-    <span ng-if="isString(signed_message)">{{signed_message}}</span>
+    <span ng-if="isString(signed_message)" style="white-space: pre-wrap;">{{signed_message}}</span>
     <ul ng-if="!isString(signed_message)">
       <li ng-repeat="(key, value) in signed_message">
         <b>{{key}}:</b> <i style="white-space: pre-wrap;">{{prettyPrint(value)}}</i><br>

--- a/public/views/modals/signed-message.html
+++ b/public/views/modals/signed-message.html
@@ -16,7 +16,7 @@
 	
 	<h4 class="title m0 row columns" translate>Message:</h4>
   <div class="m10b m10t row columns size-14 enable_text_select" style="overflow-wrap: break-word;">
-    <span ng-if="isString(signed_message)" style="white-space: pre-wrap;">{{prettyPrint(signed_message)}}</span>
+    <span ng-if="isString(signed_message)" style="white-space: pre-wrap;">{{signed_message}}</span>
     <ul ng-if="!isString(signed_message)">
       <li ng-repeat="(key, value) in signed_message">
         <b>{{key}}:</b> <i style="white-space: pre-wrap;">{{prettyPrint(value)}}</i><br>

--- a/src/js/controllers/correspondentDevice.js
+++ b/src/js/controllers/correspondentDevice.js
@@ -149,7 +149,7 @@ angular.module('copayApp.controllers').controller('correspondentDeviceController
 	$scope.requestToSignMessage = function(message){
 		if (!message || !String(message).trim())
 			return $rootScope.$emit('Local/ShowErrorAlert', "Enter a text message first");
-		chatScope.message = '[...](sign-message-request:'+ String(message).trim() +')';
+		chatScope.message = '[...](sign-message-request:'+ String(message).replace(/\n/g, ' ').trim() +')';
 		chatScope.send();
 	};
 	

--- a/src/js/controllers/correspondentDevice.js
+++ b/src/js/controllers/correspondentDevice.js
@@ -158,8 +158,8 @@ angular.module('copayApp.controllers').controller('correspondentDeviceController
 		catch(e){
 			console.log("signing a string");
 		}
-		// remove space-padding, remove new-lines and trim
-		chatScope.message = '[message](sign-message-request:'+ String(message_to_sign).replace(/\s\s/g, '').replace(/\n/g, ' ').trim() +')';
+		// remove new-lines and trim
+		chatScope.message = '[message](sign-message-request:'+ String(message_to_sign).replace(/\n/g, ' ').trim() +')';
 		chatScope.send();
 	};
 	

--- a/src/js/controllers/correspondentDevice.js
+++ b/src/js/controllers/correspondentDevice.js
@@ -146,24 +146,6 @@ angular.module('copayApp.controllers').controller('correspondentDeviceController
 	//	issueNextAddressIfNecessary(showRequestPaymentModal);
 	};
 	
-	$scope.requestToSignMessage = function(message_to_sign){
-		if (!message_to_sign || !String(message_to_sign).trim())
-			return $rootScope.$emit('Local/ShowErrorAlert', "Enter a text message first");
-		try{
-			var object_to_sign = JSON.parse(message_to_sign);
-			if (typeof object_to_sign !== 'object') throw Error("value is number or boolean");
-			message_to_sign = Buffer.from(JSON.stringify(object_to_sign), 'utf8').toString('base64');
-			console.log("signing object", object_to_sign);
-		}
-		catch(e){
-			console.log("signing a string");
-		}
-		// remove new-lines, remove space-padding and trim
-		message_to_sign = String(message_to_sign).replace(/\n/g, ' ').replace(/\s{2,}/g, ' ').trim();
-		chatScope.message = '[message](sign-message-request:'+ message_to_sign +')';
-		chatScope.send();
-	};
-	
 	$scope.sendPayment = function(address, amount, asset, device_address, base64data, from_address, single_address){
 		console.log("will send payment to "+address);
 		if (asset && $scope.index.arrBalances.filter(function(balance){ return (balance.asset === asset); }).length === 0){

--- a/src/js/controllers/correspondentDevice.js
+++ b/src/js/controllers/correspondentDevice.js
@@ -151,7 +151,7 @@ angular.module('copayApp.controllers').controller('correspondentDeviceController
 			return $rootScope.$emit('Local/ShowErrorAlert', "Enter a text message first");
 		try{
 			var object_to_sign = JSON.parse(message_to_sign);
-			if (typeof object_to_sign !== 'object') throw Error("not object");
+			if (typeof object_to_sign !== 'object') throw Error("value is number or boolean");
 			message_to_sign = Buffer.from(JSON.stringify(object_to_sign), 'utf8').toString('base64');
 			console.log("signing object", object_to_sign);
 		}

--- a/src/js/controllers/correspondentDevice.js
+++ b/src/js/controllers/correspondentDevice.js
@@ -89,6 +89,14 @@ angular.module('copayApp.controllers').controller('correspondentDeviceController
 	    	removeNewMessagesDelim();
 	});
 
+	$scope.isString = function(variable) {
+		return typeof variable === 'string';
+	};
+
+	$scope.escapeHtmlAndInsertBr = function(variable) {
+		return correspondentListService.escapeHtmlAndInsertBr($scope.isString(variable) ? variable : JSON.stringify(variable, null, '\t'));
+	};
+
 	$scope.send = function() {
 		$scope.error = null;
 		if (!$scope.message)
@@ -1025,7 +1033,7 @@ angular.module('copayApp.controllers').controller('correspondentDeviceController
 		var ModalInstanceCtrl = function($scope, $modalInstance) {
 			$scope.color = fc.backgroundColor;
 			$scope.bDisabled = true;
-			$scope.message_to_sign = correspondentListService.escapeHtmlAndInsertBr(object_to_sign ? JSON.stringify(object_to_sign, null, '\t') : message_to_sign);
+			$scope.message_to_sign = object_to_sign ? object_to_sign : message_to_sign;
 			readMyPaymentAddress(fc, function(address){
 				$scope.address = address;
 				var arrAddreses = (object_to_sign ? json : message_to_sign).match(/\b[2-7A-Z]{32}\b/g) || [];
@@ -1116,7 +1124,7 @@ angular.module('copayApp.controllers').controller('correspondentDeviceController
 		
 		var ModalInstanceCtrl = function($scope, $modalInstance) {
 			$scope.color = fc.backgroundColor;
-			$scope.signed_message = correspondentListService.escapeHtmlAndInsertBr(typeof objSignedMessage.signed_message === 'string' ? objSignedMessage.signed_message : JSON.stringify(objSignedMessage.signed_message, null, '\t'));
+			$scope.signed_message = objSignedMessage.signed_message;
 			$scope.address = objSignedMessage.authors[0].address;
 			$scope.signature = signedMessageBase64;
 			var validation = require('ocore/validation.js');

--- a/src/js/controllers/correspondentDevice.js
+++ b/src/js/controllers/correspondentDevice.js
@@ -93,7 +93,7 @@ angular.module('copayApp.controllers').controller('correspondentDeviceController
 		return typeof variable === 'string';
 	};
 
-	$scope.escapeHtmlAndInsertBr = function(variable) {
+	$scope.escapeJSONAndInsertBr = function(variable) {
 		return correspondentListService.escapeHtmlAndInsertBr($scope.isString(variable) ? variable : JSON.stringify(variable, null, '\t'));
 	};
 

--- a/src/js/controllers/correspondentDevice.js
+++ b/src/js/controllers/correspondentDevice.js
@@ -158,8 +158,9 @@ angular.module('copayApp.controllers').controller('correspondentDeviceController
 		catch(e){
 			console.log("signing a string");
 		}
-		// remove new-lines and trim
-		chatScope.message = '[message](sign-message-request:'+ String(message_to_sign).replace(/\n/g, ' ').trim() +')';
+		// remove new-lines, remove space-padding and trim
+		message_to_sign = String(message_to_sign).replace(/\n/g, ' ').replace(/\s{2,}/g, ' ').trim();
+		chatScope.message = '[message](sign-message-request:'+ message_to_sign +')';
 		chatScope.send();
 	};
 	

--- a/src/js/controllers/correspondentDevice.js
+++ b/src/js/controllers/correspondentDevice.js
@@ -158,7 +158,8 @@ angular.module('copayApp.controllers').controller('correspondentDeviceController
 		catch(e){
 			console.log("signing a string");
 		}
-		chatScope.message = '[message](sign-message-request:'+ String(message_to_sign).replace(/\n/g, ' ').trim() +')';
+		// remove space-padding, remove new-lines and trim
+		chatScope.message = '[message](sign-message-request:'+ String(message_to_sign).replace(/\s\s/g, '').replace(/\n/g, ' ').trim() +')';
 		chatScope.send();
 	};
 	

--- a/src/js/controllers/correspondentDevice.js
+++ b/src/js/controllers/correspondentDevice.js
@@ -93,8 +93,8 @@ angular.module('copayApp.controllers').controller('correspondentDeviceController
 		return typeof variable === 'string';
 	};
 
-	$scope.escapeJSONAndInsertBr = function(variable) {
-		return correspondentListService.escapeHtmlAndInsertBr($scope.isString(variable) ? variable : JSON.stringify(variable, null, '\t'));
+	$scope.prettyPrint = function(variable) {
+		return $scope.isString(variable) ? variable : JSON.stringify(variable, null, '\t');
 	};
 
 	$scope.send = function() {

--- a/src/js/controllers/correspondentDevice.js
+++ b/src/js/controllers/correspondentDevice.js
@@ -138,6 +138,13 @@ angular.module('copayApp.controllers').controller('correspondentDeviceController
 	//	issueNextAddressIfNecessary(showRequestPaymentModal);
 	};
 	
+	$scope.requestToSignMessage = function(message){
+		if (!message || !String(message).trim())
+			return $rootScope.$emit('Local/ShowErrorAlert', "Enter a text message first");
+		chatScope.message = '[...](sign-message-request:'+ message.trim() +')';
+		chatScope.send();
+	};
+	
 	$scope.sendPayment = function(address, amount, asset, device_address, base64data, from_address, single_address){
 		console.log("will send payment to "+address);
 		if (asset && $scope.index.arrBalances.filter(function(balance){ return (balance.asset === asset); }).length === 0){

--- a/src/js/controllers/correspondentDevice.js
+++ b/src/js/controllers/correspondentDevice.js
@@ -146,10 +146,19 @@ angular.module('copayApp.controllers').controller('correspondentDeviceController
 	//	issueNextAddressIfNecessary(showRequestPaymentModal);
 	};
 	
-	$scope.requestToSignMessage = function(message){
-		if (!message || !String(message).trim())
+	$scope.requestToSignMessage = function(message_to_sign){
+		if (!message_to_sign || !String(message_to_sign).trim())
 			return $rootScope.$emit('Local/ShowErrorAlert', "Enter a text message first");
-		chatScope.message = '[...](sign-message-request:'+ String(message).replace(/\n/g, ' ').trim() +')';
+		try{
+			var object_to_sign = JSON.parse(message_to_sign);
+			if (typeof object_to_sign !== 'object') throw Error("not object");
+			message_to_sign = Buffer.from(JSON.stringify(object_to_sign), 'utf8').toString('base64');
+			console.log("signing object", object_to_sign);
+		}
+		catch(e){
+			console.log("signing a string");
+		}
+		chatScope.message = '[message](sign-message-request:'+ String(message_to_sign).replace(/\n/g, ' ').trim() +')';
 		chatScope.send();
 	};
 	

--- a/src/js/controllers/correspondentDevice.js
+++ b/src/js/controllers/correspondentDevice.js
@@ -141,7 +141,7 @@ angular.module('copayApp.controllers').controller('correspondentDeviceController
 	$scope.requestToSignMessage = function(message){
 		if (!message || !String(message).trim())
 			return $rootScope.$emit('Local/ShowErrorAlert', "Enter a text message first");
-		chatScope.message = '[...](sign-message-request:'+ message.trim() +')';
+		chatScope.message = '[...](sign-message-request:'+ String(message).trim() +')';
 		chatScope.send();
 	};
 	

--- a/src/js/controllers/preferencesInformation.js
+++ b/src/js/controllers/preferencesInformation.js
@@ -130,7 +130,7 @@ angular.module('copayApp.controllers').controller('preferencesInformation',
       return typeof variable === 'string';
     };
   
-    $scope.escapeHtmlAndInsertBr = function(variable) {
+    $scope.escapeJSONAndInsertBr = function(variable) {
       return correspondentListService.escapeHtmlAndInsertBr($scope.isString(variable) ? variable : JSON.stringify(variable, null, '\t'));
     };
 

--- a/src/js/controllers/preferencesInformation.js
+++ b/src/js/controllers/preferencesInformation.js
@@ -130,8 +130,8 @@ angular.module('copayApp.controllers').controller('preferencesInformation',
       return typeof variable === 'string';
     };
   
-    $scope.escapeJSONAndInsertBr = function(variable) {
-      return correspondentListService.escapeHtmlAndInsertBr($scope.isString(variable) ? variable : JSON.stringify(variable, null, '\t'));
+    $scope.prettyPrint = function(variable) {
+      return $scope.isString(variable) ? variable : JSON.stringify(variable, null, '\t');
     };
 
     $scope.hasListOfBalances = function() {

--- a/src/js/controllers/preferencesInformation.js
+++ b/src/js/controllers/preferencesInformation.js
@@ -83,7 +83,7 @@ angular.module('copayApp.controllers').controller('preferencesInformation',
       
       var ModalInstanceCtrl = function($scope, $modalInstance) {
         $scope.color = fc.backgroundColor;
-        $scope.signed_message = correspondentListService.escapeHtmlAndInsertBr(typeof objSignedMessage.signed_message === 'string' ? objSignedMessage.signed_message : JSON.stringify(objSignedMessage.signed_message, null, '\t'));
+        $scope.signed_message = objSignedMessage.signed_message;
         $scope.address = objSignedMessage.authors[0].address;
         $scope.signature = signedMessageBase64;
         var validation = require('ocore/validation.js');
@@ -125,6 +125,14 @@ angular.module('copayApp.controllers').controller('preferencesInformation',
       });
       
     }; // verifySignedMessage
+
+    $scope.isString = function(variable) {
+      return typeof variable === 'string';
+    };
+  
+    $scope.escapeHtmlAndInsertBr = function(variable) {
+      return correspondentListService.escapeHtmlAndInsertBr($scope.isString(variable) ? variable : JSON.stringify(variable, null, '\t'));
+    };
 
     $scope.hasListOfBalances = function() {
       return !!Object.keys($scope.assocListOfBalances || {}).length;

--- a/src/js/services/correspondentListService.js
+++ b/src/js/services/correspondentListService.js
@@ -226,14 +226,12 @@ angular.module('copayApp.services').factory('correspondentListService', function
 				return '<i>[invalid signed message]</i>';
 			var objSignedMessage = info.objSignedMessage;
 			var displayed_signed_message = (typeof objSignedMessage.signed_message === 'string') ? objSignedMessage.signed_message : JSON.stringify(objSignedMessage.signed_message, null, '\t');
-			var text = 'Message signed by '+objSignedMessage.authors[0].address+': '+escapeHtml(displayed_signed_message);
+			var text = 'Message signed by '+objSignedMessage.authors[0].address+': '+escapeHtmlAndInsertBr(displayed_signed_message);
 			if (info.bValid)
 				text += " (valid)";
 			else if (info.bValid === false)
 				text += " (invalid)";
-			else
-				text += ' (<a ng-click="verifySignedMessage(\''+signedMessageBase64+'\')">verify</a>)';
-			return toDelayedReplacement('<i>['+text+']</i>');
+			return toDelayedReplacement('<a ng-click="verifySignedMessage(\''+signedMessageBase64+'\')"><i>['+text+']</i></a>');
 		}).replace(url_regexp, function(str){
 			param_index++;
 			params[param_index] = str;
@@ -457,9 +455,7 @@ angular.module('copayApp.services').factory('correspondentListService', function
 				text += " (valid)";
 			else if (info.bValid === false)
 				text += " (invalid)";
-			else
-				text += ' (<a ng-click="verifySignedMessage(\''+signedMessageBase64+'\')">verify</a>)';
-			return toDelayedReplacement('<i>['+text+']</i>');
+			return toDelayedReplacement('<a ng-click="verifySignedMessage(\''+signedMessageBase64+'\')"><i>['+text+']</i></a>');
 		}).replace(url_regexp, function(str){
 			param_index++;
 			params[param_index] = str;

--- a/src/js/services/correspondentListService.js
+++ b/src/js/services/correspondentListService.js
@@ -225,8 +225,7 @@ angular.module('copayApp.services').factory('correspondentListService', function
 			if (!info)
 				return '<i>[invalid signed message]</i>';
 			var objSignedMessage = info.objSignedMessage;
-			var displayed_signed_message = (typeof objSignedMessage.signed_message === 'string') ? objSignedMessage.signed_message : JSON.stringify(objSignedMessage.signed_message, null, '\t');
-			var text = 'Message signed by '+objSignedMessage.authors[0].address+': '+escapeHtmlAndInsertBr(displayed_signed_message);
+			var text = 'Message signed by '+objSignedMessage.authors[0].address;
 			if (info.bValid)
 				text += " (valid)";
 			else if (info.bValid === false)
@@ -379,7 +378,8 @@ angular.module('copayApp.services').factory('correspondentListService', function
 		catch(e){
 			return str; // it is already escapeHtml'd
 		}
-		return escapeHtml(JSON.stringify(obj, null, '\t'));
+		//return escapeHtml(JSON.stringify(obj, null, '\t'));
+		return escapeHtml(JSON.stringify(obj));
 	}
 	
 	function getPaymentsByAsset(objMultiPaymentRequest){
@@ -449,8 +449,7 @@ angular.module('copayApp.services').factory('correspondentListService', function
 			if (!info)
 				return '<i>[invalid signed message]</i>';
 			var objSignedMessage = info.objSignedMessage;
-			var displayed_signed_message = (typeof objSignedMessage.signed_message === 'string') ? objSignedMessage.signed_message : JSON.stringify(objSignedMessage.signed_message, null, '\t');
-			var text = 'Message signed by '+objSignedMessage.authors[0].address+': '+escapeHtmlAndInsertBr(displayed_signed_message);
+			var text = 'Message signed by '+objSignedMessage.authors[0].address;
 			if (info.bValid)
 				text += " (valid)";
 			else if (info.bValid === false)

--- a/src/js/services/correspondentListService.js
+++ b/src/js/services/correspondentListService.js
@@ -443,7 +443,7 @@ angular.module('copayApp.services').factory('correspondentListService', function
 		}).replace(/\[(.+?)\]\(profile-request:([\w,]+?)\)/g, function(str, description, fields_list){
 			return toDelayedReplacement('[Request for profile fields '+fields_list+']');
 		}).replace(/\[(.+?)\]\(sign-message-request:(.+?)\)/g, function(str, description, message_to_sign){
-			return toDelayedReplacement('<i>[Request to sign message: '+message_to_sign+']</i>');
+			return toDelayedReplacement('<i>[Request to sign message: '+tryParseBase64(message_to_sign)+']</i>');
 		}).replace(/\[(.+?)\]\(signed-message:([\w\/+=]+?)\)/g, function(str, description, signedMessageBase64){
 			var info = getSignedMessageInfoFromJsonBase64(signedMessageBase64);
 			if (!info)


### PR DESCRIPTION
* makes it possible to copy the signed message from `sign message` modal view.
* formats root level of JSON as an unordered list on `sign message` and `signed message` modal views, if JSON is nested then shows nested object values like it was showing them before.
* `Request to sign` chat message will not show JSON white-space in links anymore (it was difficult to click it and took whole screen room).
* `Message signed by` chat message will not show the same message again and is now clickable, so the user can see the details in more user friendlier `signed message` modal view.
* removed using `dynamic=""` because it will be removed some day by other PR.